### PR TITLE
Fix to allow dynamic building on MSVC

### DIFF
--- a/include/fea/structure/gamestatemachine.hpp
+++ b/include/fea/structure/gamestatemachine.hpp
@@ -20,6 +20,8 @@ namespace fea
             GameState* mCurrentState;
             std::string mCurrentStateName;
             std::unordered_map<std::string, std::unique_ptr<GameState>> gameStates;
+            GameStateMachine(const GameStateMachine &obj) = delete;
+            GameStateMachine& operator=(GameStateMachine obj) = delete;
     };
     
     /** @addtogroup Structure


### PR DESCRIPTION
#6

~~I have no clue why it works like this, but this change allows it to build. Maybe you can figure it out better than me from the following links.~~

http://stackoverflow.com/questions/767579/exporting-classes-containing-std-objects-vector-map-etc-from-a-dll
http://stackoverflow.com/questions/4145605/stdvector-needs-to-have-dll-interface-to-be-used-by-clients-of-class-xt-war
http://stackoverflow.com/questions/11189662/warning-c4251-needs-to-have-dll-interface-to-be-used-by-clients-of-class

UPDATE

I now have determined the issue was due to the compiler attempting to generate copy and copy assignment constructors that were invalid. I have now updated the PR to include those constructors and it now builds correctly.
