### PR TITLE
Pathfinding optimization (revised)

### DIFF
--- a/include/fea/util/pathfinder.inl
+++ b/include/fea/util/pathfinder.inl
@@ -3,6 +3,9 @@ typename Pathfinder<NodeProvider>::Path Pathfinder<NodeProvider>::findPath(NodeP
 {   
     auto comparator = [this] (uint32_t a, uint32_t b)
     {
+        if(fCosts[a] == fCosts[b])
+            return gCosts[a] < gCosts[b];
+
         return fCosts[a] > fCosts[b];
     };
 


### PR DESCRIPTION
In the A\* implementation, the heap comparator function should choose the node with the greater g-value if the f-values for both nodes are equal. This results in a potentially massive performance improvement, I think especially on maps with large open areas.
