### PR TITLE
Optimize C++ implementation of Simplex Noise

### DIFF
--- a/include/fea/util/simplexnoise.hpp
+++ b/include/fea/util/simplexnoise.hpp
@@ -12,6 +12,8 @@ namespace fea
 	static float dot(const int8_t* grad, float x, float y);
 	static float dot(const int8_t* grad, float x, float y, float z);
 
+	static inline int fast_floor(float x);
+
 
 	// The gradients are the midpoints of the vertices of a cube.
 	static const int8_t grad3[12][3] = {

--- a/src/util/simplexnoise.cpp
+++ b/src/util/simplexnoise.cpp
@@ -8,8 +8,8 @@ namespace fea
 		const float F2 = 0.5f * (std::sqrt(3.0f) - 1.0f);
 		float s = (x + y) * F2;
 
-		float i = std::floor(x + s);
-		float j = std::floor(y + s);
+		float i = fast_floor(x + s);
+		float j = fast_floor(y + s);
 
 		const float G2 = (3.0f - std::sqrt(3.0f)) / 6.0f;
 		float t = (i + j) * G2;
@@ -41,9 +41,9 @@ namespace fea
 		float t1 = 0.5f - x1 * x1 - y1 * y1;
 		float t2 = 0.5f - x2 * x2 - y2 * y2;
 
-		float n0 = (t0 < 0) ? 0.0f : std::pow(t0, 4) * dot(grad3[gi0], x0, y0);
-		float n1 = (t1 < 0) ? 0.0f : std::pow(t1, 4) * dot(grad3[gi1], x1, y1);
-		float n2 = (t2 < 0) ? 0.0f : std::pow(t2, 4) * dot(grad3[gi2], x2, y2);
+		float n0 = (t0 < 0) ? 0.0f : t0*t0*t0*t0 * dot(grad3[gi0], x0, y0);
+		float n1 = (t1 < 0) ? 0.0f : t1*t1*t1*t1 * dot(grad3[gi1], x1, y1);
+		float n2 = (t2 < 0) ? 0.0f : t2*t2*t2*t2 * dot(grad3[gi2], x2, y2);
 
 		return 70.0f * (n0 + n1 + n2);
 	}
@@ -54,9 +54,9 @@ namespace fea
 		float F3 = 1.0f / 3.0f;
 		float s = (x + y + z) * F3;
 
-		float i = std::floor(x + s);
-		float j = std::floor(y + s);
-		float k = std::floor(z + s);
+		float i = fast_floor(x + s);
+		float j = fast_floor(y + s);
+		float k = fast_floor(z + s);
 
 		float G3 = 1.0f / 6.0f;
 		float t = (i + j + k) * G3;
@@ -123,10 +123,10 @@ namespace fea
 		float t2 = 0.6f - x2 * x2 - y2 * y2 - z2 * z2;
 		float t3 = 0.6f - x3 * x3 - y3 * y3 - z3 * z3;
 
-		float n0 = (t0 < 0) ? 0.0f : std::pow(t0, 4) * dot(grad3[gi0], x0, y0, z0);
-		float n1 = (t1 < 0) ? 0.0f : std::pow(t1, 4) * dot(grad3[gi1], x1, y1, z1);
-		float n2 = (t2 < 0) ? 0.0f : std::pow(t2, 4) * dot(grad3[gi2], x2, y2, z2);
-		float n3 = (t3 < 0) ? 0.0f : std::pow(t3, 4) * dot(grad3[gi3], x3, y3, z3);
+		float n0 = (t0 < 0) ? 0.0f : t0*t0*t0*t0 * dot(grad3[gi0], x0, y0, z0);
+		float n1 = (t1 < 0) ? 0.0f : t1*t1*t1*t1 * dot(grad3[gi1], x1, y1, z1);
+		float n2 = (t2 < 0) ? 0.0f : t2*t2*t2*t2 * dot(grad3[gi2], x2, y2, z2);
+		float n3 = (t3 < 0) ? 0.0f : t3*t3*t3*t3 * dot(grad3[gi3], x3, y3, z3);
 
 		return 32.0f * (n0 + n1 + n2 + n3);
 	}
@@ -159,4 +159,6 @@ namespace fea
 	{
 		return grad[0] * x + grad[1] * y + grad[2] * z;
 	}
+
+	static inline int fast_floor(float x){return ((x>=0)?((int)x):((x==(int)x)?(int)x:((int)x)-1));}
 }


### PR DESCRIPTION
This PR optimizes the simplex noise implementations of `fea-util` by:
- Replacing `std::pow()` with expanded exponents
- Replacing `std::floor()` with a faster implementation that works using type casts

This method is better than the ASM optimization because:
- It's faster
- It's platform independent
- Sorry @FredYeye 

The speed increase is around 32% on my Intel i7 4770:

``` c++
/*
Built on ArchLinux x86_64 with GCC 4.9.1
Featherkit-util linked as static library
CPU: Intel Core i7 4770 @ 3.4 GHz
Tests were performed with TurboBoost on, and the clock speed was 3.75GHz

Featherkit with `-O3`:
    - C++ Noise:
        - With std::pow():
            - Times (min, max, avg): 18500990us, 19314295us, 18761359us
        - With expanded exponent:
            - Times (min, max, avg): 13590441us, 13778924us, 13641680us
        - With expanded exponent and fast_floor:
            - Times (min, max, avg): 12741825us, 12785273us, 12761292us
    - ASM Noise:
            - Times (min, max, avg): 17619293us, 18048159us, 17756850us

Featherkit with `-O3 -march=native -mfpmath=sse`:
    - C++ Noise:
        - With std::pow():
            - Times (min, max, avg): 16363849us, 16540378us, 16425663us
        - With expanded exponent:
            - Times (min, max, avg): 12010800us, 12160890us, 12042282us
        - With expanded exponent and fast_floor:
            - Times (min, max, avg): 11155214us, 11217809us, 11175114us
    - ASM Noise:
            - Times (min, max, avg): 17765922us, 17830874us, 17787408us


    If I compile the example with `-O3 -march=native -mfpmath=sse`, I get:
    - C++ Noise:
        - With expanded exponent:
            - Times (min, max, avg): 11598168us, 11839490us, 11654674us
        - With expanded exponent and fast_floor:
            - Times (min, max, avg): 10935452us, 10988102us, 10964837us

*/
```

The test program I used can be found here: https://gist.github.com/Mischa-Alff/e6407a9a9b5894a317a1
