### PR TITLE
Removed leading 0 from array initializer

### DIFF
--- a/include/fea/util/messagebus.hpp
+++ b/include/fea/util/messagebus.hpp
@@ -37,7 +37,7 @@ namespace fea
     void subscribe(MessageBus& bus, MessageReceiver<MessageTypes...>& receiver, bool unsubscribe)
     {
         std::vector<std::function<void()>> desubscribers;
-        int _[] = {0, (subscribeToType<MessageTypes>(bus, receiver, desubscribers, unsubscribe), 0)...};
+        int _[] = {(subscribeToType<MessageTypes>(bus, receiver, desubscribers, unsubscribe), 0)...};
         (void)_;
         receiver.mDesubscribers = desubscribers;
     }


### PR DESCRIPTION
subscribe() uses the array initializer to execute the template function
subscribeToType() for every parameter in the parameter pack of the
variadic template function 'subscribe()'.

A leading 0 was included in the array initializer. However it serves no
function. I have removed the 0 in this commit.
