### PR TITLE
Fixed find_path in FindJsonCpp.cmake

### DIFF
--- a/cmake/modules/FindJsonCpp.cmake
+++ b/cmake/modules/FindJsonCpp.cmake
@@ -9,9 +9,11 @@ if(JSONCPP_INCLUDE_DIR)
     set(JSONCPP_FIND_QUIETLY TRUE)
 endif(JSONCPP_INCLUDE_DIR)
 
-find_path(JSONCPP_INCLUDE_DIR jsoncpp/json/json.h
-    /usr/local/include
+find_path(JSONCPP_INCLUDE_DIR json/json.h
     /usr/include
+    /usr/local/include
+    /usr/include/jsoncpp
+    /usr/local/include/jsoncpp
     )
 
 set(JSONCPP_NAMES ${JSONCPP_NAMES} libjsoncpp.so)
@@ -21,7 +23,7 @@ find_library(JSONCPP_LIBRARY
     )
 
 if(JSONCPP_LIBRARY AND JSONCPP_INCLUDE_DIR)
-    set(JSONCPP_INCLUDE_DIRS ${JSONCPP_INCLUDE_DIR} ${JSONCPP_INCLUDE_DIR}/jsoncpp)
+    set(JSONCPP_INCLUDE_DIRS ${JSONCPP_INCLUDE_DIR})
     set(JSONCPP_LIBRARIES ${JSONCPP_LIBRARY})
     set(JSONCPP_FOUND "YES")
 else(JSONCPP_LIBRARY AND JSONCPP_INCLUDE_DIR)

--- a/cmake/modules/FindJsonCpp.cmake
+++ b/cmake/modules/FindJsonCpp.cmake
@@ -10,6 +10,10 @@ if(JSONCPP_INCLUDE_DIR)
 endif(JSONCPP_INCLUDE_DIR)
 
 find_path(JSONCPP_INCLUDE_DIR json/json.h
+    /include
+    /include/jsoncpp
+    /local/include
+    /local/include/jsoncpp
     /usr/include
     /usr/local/include
     /usr/include/jsoncpp
@@ -19,7 +23,7 @@ find_path(JSONCPP_INCLUDE_DIR json/json.h
 set(JSONCPP_NAMES ${JSONCPP_NAMES} libjsoncpp.so)
 find_library(JSONCPP_LIBRARY
     NAMES ${JSONCPP_NAMES}
-    PATHS /usr/lib /usr/local/lib
+    PATHS /lib /local/lib /usr/lib /usr/local/lib
     )
 
 if(JSONCPP_LIBRARY AND JSONCPP_INCLUDE_DIR)


### PR DESCRIPTION
Today I got a new jsoncpp version on my Arch linux system, and found that it now installs its includes in `/usr/include/json` instead of `/usr/include/jsoncpp/json` (which I am kind of surprised about, because I'd expect the name json directly in the systems include directory to be used by other libraries).

Because I did some work on the jsoncpp integration in featherkit I verified whether featherkit would still compile with the new jsoncpp version. It did well when I got to compiling, but before that I got an error from CMake complaining that it can't find jsoncpp's include directory. It seems when writing the FindJsonCpp.cmake file, I was thinking too much about how to handle the hacky thing Arch Linux did with the package (and other Linux distributions did or still do too) that I forgot to test whether everything worked with the `json.h` file being in `${includedir}/json` instead of the `${includedir}/jsoncpp/json`. This patch fixes the cmake module to work with both variants.